### PR TITLE
Supervisor hibernation

### DIFF
--- a/lib/sasl/test/release_handler_SUITE.erl
+++ b/lib/sasl/test/release_handler_SUITE.erl
@@ -1661,7 +1661,7 @@ upgrade_supervisor(Conf) when is_list(Conf) ->
     %% Check that the restart strategy and child spec is updated
     {status, _, {module, _}, [_, _, _, _, [_,_,{data,[{"State",State}]}|_]]} =
 	rpc:call(Node,sys,get_status,[a_sup]),
-    {state,_,RestartStrategy,{[a],Db},_,_,_,_,_,_,_,_,_} = State,
+    {state,_,RestartStrategy,{[a],Db},_,_,_,_,_,_,_,_,_,_} = State,
     one_for_all = RestartStrategy, % changed from one_for_one
     {child,_,_,_,_,_,brutal_kill,_,_} = maps:get(a,Db), % changed from timeout 2000
 

--- a/lib/ssl/src/tls_dyn_connection_sup.erl
+++ b/lib/ssl/src/tls_dyn_connection_sup.erl
@@ -50,7 +50,8 @@ init([SenderArgs, ReciverArgs]) ->
     SupFlags = #{strategy      => one_for_all,
                  auto_shutdown => any_significant,
                  intensity     =>    0,
-                 period        => 3600
+                 period        => 3600,
+                 hibernate_after => 1000
                 },
     ChildSpecs = [sender(SenderArgs), receiver(ReciverArgs)],
     {ok, {SupFlags, ChildSpecs}}.

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -110,6 +110,18 @@ all child processes and then itself. The termination reason for the supervisor
 itself in that case will be `shutdown`. `intensity` defaults to `1` and `period`
 defaults to `5`.
 
+#### Hibernate after
+
+In order to save memory, a supervisor, like any other process, can go into
+hibernation. By default, a `simple_one_for_one` supervisor will never hibernate,
+as it is expected its children will come and go at potentially high rates.
+In counterpart, other strategies rather expect children to be stable and
+therefore will default to hibernating after a `period` of time of inactivity,
+in order to be responsive to bursts of restarts and save memory in periods of
+stability. You can however finetune this flag by setting `hibernate_after`,
+when for example the supervisor will be regularly queried for `which_child/1`
+or similar and hibernation is to be better controlled.
+
 [](){: #auto_shutdown }
 
 #### Automatic Shutdown

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1199,7 +1199,7 @@ count_child(#child{pid = Pid, child_type = supervisor},
 -spec handle_cast({try_again_restart, reference(), child_id() | {'restarting',pid()}}, state()) ->
 			 {'noreply', state(), gen_server:action()} | {stop, shutdown, state()}.
 
-handle_cast({try_again_restart, HRef, TryAgainId}, #state{tag = HRef} = State) ->
+handle_cast({try_again_restart, Tag, TryAgainId}, #state{tag = Tag} = State) ->
     case find_child_and_args(TryAgainId, State) of
 	{ok, Child = #child{pid=?restarting(_)}} ->
 	    case restart(Child,State) of
@@ -1219,7 +1219,7 @@ handle_cast({try_again_restart, HRef, TryAgainId}, #state{tag = HRef} = State) -
 -spec handle_info(term(), state()) ->
         {'noreply', state(), gen_server:action()} | {'stop', 'shutdown', state()}.
 
-handle_info({HRef, hibernate}, #state{tag = HRef} = State) ->
+handle_info({hibernate, Tag}, #state{tag = Tag} = State) ->
     {noreply, State, hibernate};
 
 handle_info({'EXIT', Pid, Reason}, State) ->
@@ -1495,8 +1495,8 @@ restarting(Pid) when is_pid(Pid) -> ?restarting(Pid);
 restarting(RPid) -> RPid.
 
 -spec try_again_restart(child_id() | {'restarting',pid()}, reference()) -> 'ok'.
-try_again_restart(TryAgainId, HRef) ->
-    gen_server:cast(self(), {try_again_restart, HRef, TryAgainId}).
+try_again_restart(TryAgainId, Tag) ->
+    gen_server:cast(self(), {try_again_restart, Tag, TryAgainId}).
 
 %%-----------------------------------------------------------------
 %% Func: terminate_children/2
@@ -2026,8 +2026,8 @@ validHibernateAfter(What) ->
     throw({invalid_hibernate_after, What}).
 
 -compile({inline, [hibernate_after_action/1]}).
-hibernate_after_action(#state{tag = HRef, hibernate_after = HibernateAfter}) ->
-    {timeout, HibernateAfter, {HRef, hibernate}}.
+hibernate_after_action(#state{tag = Tag, hibernate_after = HibernateAfter}) ->
+    {timeout, HibernateAfter, {hibernate, Tag}}.
 
 default_hibernate_after(simple_one_for_one) ->
     infinity;

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -116,11 +116,11 @@ In order to save memory, a supervisor, like any other process, can go into
 hibernation. By default, a `simple_one_for_one` supervisor will never hibernate,
 as it is expected its children will come and go at potentially high rates.
 In counterpart, other strategies rather expect children to be stable and
-therefore will default to hibernating after a `period` of time of inactivity,
-in order to be responsive to bursts of restarts and save memory in periods of
-stability. You can however finetune this flag by setting `hibernate_after`,
-when for example the supervisor will be regularly queried for `which_child/1`
-or similar and hibernation is to be better controlled.
+therefore will default to hibernating after a certain period of time of
+inactivity, in order to be responsive to bursts of restarts and save memory in
+periods of stability. You can finetune this flag by setting `hibernate_after`,
+when for example the supervisor will be regularly queried for `which_child/1` or
+similar and hibernation is to be better controlled.
 
 [](){: #auto_shutdown }
 

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -464,7 +464,6 @@ see more details [above](`m:supervisor#sup_flags`).
 -type child_rec() :: #child{}.
 
 -record(state, {name,
-		tag = make_ref()       :: reference(),
 		strategy = one_for_one :: strategy(),
 		children = {[],#{}}    :: children(), % Ids in start order
                 dynamics               :: {'maps', #{pid() => list()}}
@@ -477,6 +476,7 @@ see more details [above](`m:supervisor#sup_flags`).
 		dynamic_restarts = 0   :: non_neg_integer(),
 		auto_shutdown = never  :: auto_shutdown(),
 		hibernate_after = infinity :: timeout(),
+		tag = make_ref()       :: reference(),
 	        module,
 	        args}).
 -type state() :: #state{}.

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -63,7 +63,8 @@ definition for the supervisor flags is as follows:
 sup_flags() = #{strategy => strategy(),           % optional
                 intensity => non_neg_integer(),   % optional
                 period => pos_integer(),          % optional
-                auto_shutdown => auto_shutdown()} % optional
+                auto_shutdown => auto_shutdown(), % optional
+                hibernate_after => timeout()}     % optional
 ```
 
 #### Restart Strategies
@@ -417,7 +418,8 @@ see more details [above](`m:supervisor#sup_flags`).
 -type sup_flags() :: #{strategy => strategy(),           % optional
 		       intensity => non_neg_integer(),   % optional
 		       period => pos_integer(),          % optional
-		       auto_shutdown => auto_shutdown()} % optional
+		       auto_shutdown => auto_shutdown(), % optional
+		       hibernate_after => timeout()}     % optional
                    | {RestartStrategy :: strategy(),
                       Intensity :: non_neg_integer(),
                       Period :: pos_integer()}.
@@ -425,12 +427,13 @@ see more details [above](`m:supervisor#sup_flags`).
 
 %%--------------------------------------------------------------------------
 %% Defaults
--define(default_flags, #{strategy      => one_for_one,
-			 intensity     => 1,
-			 period        => 5,
-			 auto_shutdown => never}).
--define(default_child_spec, #{restart  => permanent,
-			      type     => worker}).
+-define(default_flags, #{strategy        => one_for_one,
+			 intensity       => 1,
+			 period          => 5,
+			 auto_shutdown   => never,
+			 hibernate_after => undefined}).
+-define(default_child_spec, #{restart    => permanent,
+			      type       => worker}).
 %% Default 'shutdown' is 5000 for workers and infinity for supervisors.
 %% Default 'modules' is [M], where M comes from the child's start {M,F,A}.
 
@@ -461,6 +464,7 @@ see more details [above](`m:supervisor#sup_flags`).
                 nrestarts = 0,
 		dynamic_restarts = 0   :: non_neg_integer(),
 		auto_shutdown = never  :: auto_shutdown(),
+		hibernate_after        :: 'undefined' | timeout(),
 	        module,
 	        args}).
 -type state() :: #state{}.
@@ -916,7 +920,11 @@ init_children(State, StartSpec) ->
                     %% Static supervisor are not expected to
                     %% have much work to do so hibernate them
                     %% to improve memory handling.
-                    {ok, State#state{children = NChildren}, hibernate};
+		    {HibernateAfter, TimeoutOrHibernate} = case State#state.hibernate_after of
+							       undefined -> {infinity, hibernate};
+							       Timeout -> {Timeout, Timeout}
+							   end,
+                    {ok, State#state{children = NChildren, hibernate_after = HibernateAfter}, TimeoutOrHibernate};
                 {error, NChildren, Reason} ->
                     _ = terminate_children(NChildren, SupName),
                     {stop, {shutdown, Reason}}
@@ -931,7 +939,11 @@ init_dynamic(State, [StartSpec]) ->
             %% Simple one for one supervisors are expected to
             %% have many children coming and going so do not
             %% hibernate.
-	    {ok, dyn_init(State#state{children = Children})};
+	    HibernateAfter = case State#state.hibernate_after of
+				 undefined -> infinity;
+				 Timeout -> Timeout
+			     end,
+	    {ok, dyn_init(State#state{children = Children, hibernate_after = HibernateAfter}), HibernateAfter};
         Error ->
             {stop, {start_spec, Error}}
     end;
@@ -1009,43 +1021,43 @@ handle_call({start_child, EArgs}, _From, State) when ?is_simple(State) ->
     Args = A ++ EArgs,
     case do_start_child_i(M, F, Args) of
 	{ok, undefined} ->
-	    {reply, {ok, undefined}, State};
+	    {reply, {ok, undefined}, State, State#state.hibernate_after};
 	{ok, Pid} ->
 	    NState = dyn_store(Pid, Args, State),
-	    {reply, {ok, Pid}, NState};
+	    {reply, {ok, Pid}, NState, State#state.hibernate_after};
 	{ok, Pid, Extra} ->
 	    NState = dyn_store(Pid, Args, State),
-	    {reply, {ok, Pid, Extra}, NState};
+	    {reply, {ok, Pid, Extra}, NState, State#state.hibernate_after};
 	What ->
-	    {reply, What, State}
+	    {reply, What, State, State#state.hibernate_after}
     end;
 
 handle_call({start_child, ChildSpec}, _From, State) ->
     case check_childspec(ChildSpec, State#state.auto_shutdown) of
 	{ok, Child} ->
 	    {Resp, NState} = handle_start_child(Child, State),
-	    {reply, Resp, NState};
+	    {reply, Resp, NState, State#state.hibernate_after};
 	What ->
-	    {reply, {error, What}, State}
+	    {reply, {error, What}, State, State#state.hibernate_after}
     end;
 
 %% terminate_child for simple_one_for_one can only be done with pid
 handle_call({terminate_child, Id}, _From, State) when not is_pid(Id),
                                                       ?is_simple(State) ->
-    {reply, {error, simple_one_for_one}, State};
+    {reply, {error, simple_one_for_one}, State, State#state.hibernate_after};
 
 handle_call({terminate_child, Id}, _From, State) ->
     case find_child(Id, State) of
 	{ok, Child} ->
 	    do_terminate(Child, State#state.name),
-            {reply, ok, del_child(Child, State)};
+            {reply, ok, del_child(Child, State), State#state.hibernate_after};
 	error ->
-	    {reply, {error, not_found}, State}
+	    {reply, {error, not_found}, State, State#state.hibernate_after}
     end;
 
 %% restart_child request is invalid for simple_one_for_one supervisors
 handle_call({restart_child, _Id}, _From, State) when ?is_simple(State) ->
-    {reply, {error, simple_one_for_one}, State};
+    {reply, {error, simple_one_for_one}, State, State#state.hibernate_after};
 
 handle_call({restart_child, Id}, _From, State) ->
     case find_child(Id, State) of
@@ -1053,44 +1065,44 @@ handle_call({restart_child, Id}, _From, State) ->
 	    case do_start_child(State#state.name, Child, debug_report) of
 		{ok, Pid} ->
 		    NState = set_pid(Pid, Id, State),
-		    {reply, {ok, Pid}, NState};
+		    {reply, {ok, Pid}, NState, State#state.hibernate_after};
 		{ok, Pid, Extra} ->
 		    NState = set_pid(Pid, Id, State),
-		    {reply, {ok, Pid, Extra}, NState};
+		    {reply, {ok, Pid, Extra}, NState, State#state.hibernate_after};
 		Error ->
-		    {reply, Error, State}
+		    {reply, Error, State, State#state.hibernate_after}
 	    end;
 	{ok, #child{pid=?restarting(_)}} ->
-	    {reply, {error, restarting}, State};
+	    {reply, {error, restarting}, State, State#state.hibernate_after};
 	{ok, _} ->
-	    {reply, {error, running}, State};
+	    {reply, {error, running}, State, State#state.hibernate_after};
 	_ ->
-	    {reply, {error, not_found}, State}
+	    {reply, {error, not_found}, State, State#state.hibernate_after}
     end;
 
 %% delete_child request is invalid for simple_one_for_one supervisors
 handle_call({delete_child, _Id}, _From, State) when ?is_simple(State) ->
-    {reply, {error, simple_one_for_one}, State};
+    {reply, {error, simple_one_for_one}, State, State#state.hibernate_after};
 
 handle_call({delete_child, Id}, _From, State) ->
     case find_child(Id, State) of
 	{ok, Child} when Child#child.pid =:= undefined ->
 	    NState = remove_child(Id, State),
-	    {reply, ok, NState};
+	    {reply, ok, NState, State#state.hibernate_after};
 	{ok, #child{pid=?restarting(_)}} ->
-	    {reply, {error, restarting}, State};
+	    {reply, {error, restarting}, State, State#state.hibernate_after};
 	{ok, _} ->
-	    {reply, {error, running}, State};
+	    {reply, {error, running}, State, State#state.hibernate_after};
 	_ ->
-	    {reply, {error, not_found}, State}
+	    {reply, {error, not_found}, State, State#state.hibernate_after}
     end;
 
 handle_call({get_childspec, Id}, _From, State) ->
     case find_child(Id, State) of
 	{ok, Child} ->
-            {reply, {ok, child_to_spec(Child)}, State};
+            {reply, {ok, child_to_spec(Child)}, State, State#state.hibernate_after};
 	error ->
-	    {reply, {error, not_found}, State}
+	    {reply, {error, not_found}, State, State#state.hibernate_after}
     end;
 
 handle_call(which_children, _From, State) when ?is_simple(State) ->
@@ -1098,7 +1110,7 @@ handle_call(which_children, _From, State) when ?is_simple(State) ->
     Reply = dyn_map(fun(?restarting(_)) -> {undefined, restarting, CT, Mods};
                        (Pid) -> {undefined, Pid, CT, Mods}
                     end, State),
-    {reply, Reply, State};
+    {reply, Reply, State, State#state.hibernate_after};
 
 handle_call(which_children, _From, State) ->
     Resp =
@@ -1111,12 +1123,12 @@ handle_call(which_children, _From, State) ->
                   {Id, Pid, ChildType, Mods}
           end,
           State#state.children),
-    {reply, Resp, State};
+    {reply, Resp, State, State#state.hibernate_after};
 
 %% which_child for simple_one_for_one can only be done with pid
 handle_call({which_child, Id}, _From, State) when not is_pid(Id),
                                                   ?is_simple(State) ->
-    {reply, {error, simple_one_for_one}, State};
+    {reply, {error, simple_one_for_one}, State, State#state.hibernate_after};
 
 handle_call({which_child, Pid}, _From, State) when ?is_simple(State) ->
     Result = case find_dynamic_child(Pid, State) of
@@ -1129,7 +1141,7 @@ handle_call({which_child, Pid}, _From, State) when ?is_simple(State) ->
 		 error ->
 		     {error, not_found}
 	     end,
-    {reply, Result, State};
+    {reply, Result, State, State#state.hibernate_after};
 
 handle_call({which_child, Id}, _From, State) ->
     Result = case find_child(Id, State) of
@@ -1142,7 +1154,7 @@ handle_call({which_child, Id}, _From, State) ->
 		 error ->
 		     {error, not_found}
 	     end,
-    {reply, Result, State};
+    {reply, Result, State, State#state.hibernate_after};
 
 handle_call(count_children, _From,  #state{dynamic_restarts = Restarts} = State)
   when ?is_simple(State) ->
@@ -1155,7 +1167,7 @@ handle_call(count_children, _From,  #state{dynamic_restarts = Restarts} = State)
 		worker -> [{specs, 1}, {active, Active},
 			   {supervisors, 0}, {workers, Sz}]
 	    end,
-    {reply, Reply, State};
+    {reply, Reply, State, State#state.hibernate_after};
 
 handle_call(count_children, _From, State) ->
     %% Specs and children are together on the children list...
@@ -1167,7 +1179,7 @@ handle_call(count_children, _From, State) ->
     %% Reformat counts to a property list.
     Reply = [{specs, Specs}, {active, Active},
 	     {supervisors, Supers}, {workers, Workers}],
-    {reply, Reply, State}.
+    {reply, Reply, State, State#state.hibernate_after}.
 
 count_child(#child{pid = Pid, child_type = worker},
 	    {Specs, Active, Supers, Workers}) ->
@@ -1194,12 +1206,12 @@ handle_cast({try_again_restart,TryAgainId}, State) ->
 	{ok, Child = #child{pid=?restarting(_)}} ->
 	    case restart(Child,State) of
 		{ok, State1} ->
-		    {noreply, State1};
+		    {noreply, State1, State1#state.hibernate_after};
 		{shutdown, State1} ->
 		    {stop, shutdown, State1}
 	    end;
 	_ ->
-	    {noreply,State}
+	    {noreply,State, State#state.hibernate_after}
     end.
 
 %%
@@ -1209,10 +1221,14 @@ handle_cast({try_again_restart,TryAgainId}, State) ->
 -spec handle_info(term(), state()) ->
         {'noreply', state()} | {'stop', 'shutdown', state()}.
 
+handle_info(timeout, State) ->
+    logger:notice("Hibernating supervisor ~p", [self()]),
+    {noreply, State, hibernate};
+
 handle_info({'EXIT', Pid, Reason}, State) ->
     case restart_child(Pid, Reason, State) of
 	{ok, State1} ->
-	    {noreply, State1};
+	    {noreply, State1, State1#state.hibernate_after};
 	{shutdown, State1} ->
 	    {stop, shutdown, State1}
     end;
@@ -1221,7 +1237,7 @@ handle_info(Msg, State) ->
     ?LOG_ERROR("Supervisor received unexpected message: ~tp~n",[Msg],
                #{domain=>[otp],
                  error_logger=>#{tag=>error}}),
-    {noreply, State}.
+    {noreply, State, State#state.hibernate_after}.
 
 %%
 %% Terminate this server.
@@ -1937,16 +1953,18 @@ init_state(SupName, Type, Mod, Args) ->
     set_flags(Type, #state{name = supname(SupName,Mod),
 			   module = Mod,
 			   args = Args,
-			   auto_shutdown = never}).
+			   auto_shutdown = never,
+			   hibernate_after = undefined}).
 
 set_flags(Flags, State) ->
     try check_flags(Flags) of
 	#{strategy := Strategy, intensity := MaxIntensity, period := Period,
-	  auto_shutdown := AutoShutdown} ->
+	  auto_shutdown := AutoShutdown, hibernate_after := HibernateAfter} ->
 	    {ok, State#state{strategy = Strategy,
 			     intensity = MaxIntensity,
 			     period = Period,
-			     auto_shutdown = AutoShutdown}}
+			     auto_shutdown = AutoShutdown,
+			     hibernate_after = HibernateAfter}}
     catch
 	Thrown -> Thrown
     end.
@@ -1957,19 +1975,22 @@ check_flags({Strategy, MaxIntensity, Period}) ->
     check_flags(#{strategy => Strategy,
 		  intensity => MaxIntensity,
 		  period => Period,
-		  auto_shutdown => never});
+		  auto_shutdown => never,
+		  hibernate_after => undefined});
 check_flags(What) ->
     throw({invalid_type, What}).
 
 do_check_flags(#{strategy := Strategy,
 		 intensity := MaxIntensity,
 		 period := Period,
-		 auto_shutdown := AutoShutdown} = Flags) ->
+		 auto_shutdown := AutoShutdown,
+		 hibernate_after := HibernateAfter} = Flags) ->
     validStrategy(Strategy),
     validIntensity(MaxIntensity),
     validPeriod(Period),
     validAutoShutdown(AutoShutdown),
     validAutoShutdownForStrategy(AutoShutdown, Strategy),
+    validHibernateAfter(HibernateAfter),
     Flags.
 
 validStrategy(simple_one_for_one) -> true;
@@ -1997,6 +2018,14 @@ validAutoShutdownForStrategy(all_significant, simple_one_for_one) ->
     throw({bad_combination, [{auto_shutdown, all_significant}, {strategy, simple_one_for_one}]});
 validAutoShutdownForStrategy(_AutoShutdown, _Strategy) ->
     true.
+
+validHibernateAfter(undefined) ->
+    true;
+validHibernateAfter(Timeout) when Timeout =:= infinity;
+				  is_integer(Timeout), Timeout >= 0 ->
+    true;
+validHibernateAfter(What) ->
+    throw({invalid_hibernate_after, What}).
 
 
 supname(self, Mod) -> {self(), Mod};

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -464,7 +464,8 @@ see more details [above](`m:supervisor#sup_flags`).
 -type child_rec() :: #child{}.
 
 -record(state, {name,
-		strategy = one_for_one:: strategy(),
+		tag = make_ref()       :: reference(),
+		strategy = one_for_one :: strategy(),
 		children = {[],#{}}    :: children(), % Ids in start order
                 dynamics               :: {'maps', #{pid() => list()}}
                                         | {'mapsets', #{pid() => []}}
@@ -475,7 +476,6 @@ see more details [above](`m:supervisor#sup_flags`).
                 nrestarts = 0,
 		dynamic_restarts = 0   :: non_neg_integer(),
 		auto_shutdown = never  :: auto_shutdown(),
-		hibernate_after_ref = make_ref() :: reference(),
 		hibernate_after = infinity :: timeout(),
 	        module,
 	        args}).
@@ -1219,7 +1219,7 @@ handle_cast({try_again_restart,TryAgainId}, State) ->
 -spec handle_info(term(), state()) ->
         {'noreply', state(), gen_server:action()} | {'stop', 'shutdown', state()}.
 
-handle_info(HRef, #state{hibernate_after_ref = HRef} = State) ->
+handle_info({HRef, hibernate}, #state{tag = HRef} = State) ->
     {noreply, State, hibernate};
 
 handle_info({'EXIT', Pid, Reason}, State) ->
@@ -1969,15 +1969,13 @@ check_flags(SupFlags) when is_map(SupFlags) ->
     case maps:merge(?default_flags, SupFlags) of
 	#{hibernate_after := _} = MergedFlags ->
 	    do_check_flags(MergedFlags);
-	#{strategy := Strategy, period := Period} = MergedFlags ->
-	    do_check_flags(MergedFlags#{hibernate_after => default_hibernate_after(Strategy, Period)})
+	#{strategy := Strategy} = MergedFlags ->
+	    do_check_flags(MergedFlags#{hibernate_after => default_hibernate_after(Strategy)})
     end;
 check_flags({Strategy, MaxIntensity, Period}) ->
     check_flags(#{strategy => Strategy,
 		  intensity => MaxIntensity,
-		  period => Period,
-		  auto_shutdown => never,
-		  hibernate_after => default_hibernate_after(Strategy, Period)});
+		  period => Period});
 check_flags(What) ->
     throw({invalid_type, What}).
 
@@ -2027,21 +2025,17 @@ validHibernateAfter(Timeout) when is_integer(Timeout), Timeout >= 0 ->
 validHibernateAfter(What) ->
     throw({invalid_hibernate_after, What}).
 
+-compile({inline, [hibernate_after_action/1]}).
+hibernate_after_action(#state{tag = HRef, hibernate_after = HibernateAfter}) ->
+    {timeout, HibernateAfter, {HRef, hibernate}}.
+
+default_hibernate_after(simple_one_for_one) ->
+    infinity;
+default_hibernate_after(_) ->
+    1000.
 
 supname(self, Mod) -> {self(), Mod};
 supname(N, _)      -> N.
-
-
--compile({inline, [hibernate_after_action/1]}).
-hibernate_after_action(#state{hibernate_after_ref = HRef, hibernate_after = HibernateAfter}) ->
-    {timeout, HibernateAfter, HRef}.
-
-default_hibernate_after(simple_one_for_one, _) ->
-    infinity;
-default_hibernate_after(_, infinity) ->
-    5000;
-default_hibernate_after(_, Period) ->
-    1000 * Period.
 
 %%% ------------------------------------------------------
 %%% Check that the children start specification is valid.

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1196,10 +1196,10 @@ count_child(#child{pid = Pid, child_type = supervisor},
 %%% from restart/2 in order to give gen_server the chance to
 %%% check it's inbox before trying again.
 -doc false.
--spec handle_cast({try_again_restart, child_id() | {'restarting',pid()}}, state()) ->
+-spec handle_cast({try_again_restart, reference(), child_id() | {'restarting',pid()}}, state()) ->
 			 {'noreply', state(), gen_server:action()} | {stop, shutdown, state()}.
 
-handle_cast({try_again_restart,TryAgainId}, State) ->
+handle_cast({try_again_restart, HRef, TryAgainId}, #state{tag = HRef} = State) ->
     case find_child_and_args(TryAgainId, State) of
 	{ok, Child = #child{pid=?restarting(_)}} ->
 	    case restart(Child,State) of
@@ -1409,7 +1409,7 @@ restart(Child, State) ->
 		    %% for the supervisor can be handled - e.g. a
 		    %% shutdown request for the supervisor or the
 		    %% child.
-                    try_again_restart(TryAgainId),
+                    try_again_restart(TryAgainId, NState2#state.tag),
 		    {ok,NState2};
 		Other ->
 		    Other
@@ -1494,9 +1494,9 @@ restart_multiple_children(Child, Children, SupName) ->
 restarting(Pid) when is_pid(Pid) -> ?restarting(Pid);
 restarting(RPid) -> RPid.
 
--spec try_again_restart(child_id() | {'restarting',pid()}) -> 'ok'.
-try_again_restart(TryAgainId) ->
-    gen_server:cast(self(), {try_again_restart, TryAgainId}).
+-spec try_again_restart(child_id() | {'restarting',pid()}, reference()) -> 'ok'.
+try_again_restart(TryAgainId, HRef) ->
+    gen_server:cast(self(), {try_again_restart, HRef, TryAgainId}).
 
 %%-----------------------------------------------------------------
 %% Func: terminate_children/2

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -63,8 +63,8 @@ definition for the supervisor flags is as follows:
 sup_flags() = #{strategy => strategy(),           % optional
                 intensity => non_neg_integer(),   % optional
                 period => pos_integer(),          % optional
-                auto_shutdown => auto_shutdown(), % optional
-                hibernate_after => timeout()}     % optional
+                hibernate_after => timeout(),     % optional
+                auto_shutdown => auto_shutdown()} % optional
 ```
 
 #### Restart Strategies
@@ -463,7 +463,8 @@ see more details [above](`m:supervisor#sup_flags`).
                 nrestarts = 0,
 		dynamic_restarts = 0   :: non_neg_integer(),
 		auto_shutdown = never  :: auto_shutdown(),
-		hibernate_after        :: timeout(),
+		hibernate_after_ref = make_ref() :: reference(),
+		hibernate_after = infinity :: timeout(),
 	        module,
 	        args}).
 -type state() :: #state{}.
@@ -916,7 +917,7 @@ init_children(State, StartSpec) ->
         {ok, Children} ->
             case start_children(Children, SupName) of
                 {ok, NChildren} ->
-                    {ok, State#state{children = NChildren}, State#state.hibernate_after};
+                    {ok, State#state{children = NChildren}, hibernate_after_action(State)};
                 {error, NChildren, Reason} ->
                     _ = terminate_children(NChildren, SupName),
                     {stop, {shutdown, Reason}}
@@ -928,7 +929,7 @@ init_children(State, StartSpec) ->
 init_dynamic(State, [StartSpec]) ->
     case check_startspec([StartSpec], State#state.auto_shutdown) of
         {ok, Children} ->
-	    {ok, dyn_init(State#state{children = Children}), State#state.hibernate_after};
+	    {ok, dyn_init(State#state{children = Children}), hibernate_after_action(State)};
         Error ->
             {stop, {start_spec, Error}}
     end;
@@ -998,7 +999,7 @@ do_start_child_i(M, F, A) ->
 %%% ---------------------------------------------------
 -type call() :: 'which_children' | 'count_children' | {_, _}.	% XXX: refine
 -doc false.
--spec handle_call(call(), term(), state()) -> {'reply', term(), state()}.
+-spec handle_call(call(), term(), state()) -> {'reply', term(), state(), gen_server:action()}.
 
 handle_call({start_child, EArgs}, _From, State) when ?is_simple(State) ->
     Child = get_dynamic_child(State),
@@ -1006,43 +1007,43 @@ handle_call({start_child, EArgs}, _From, State) when ?is_simple(State) ->
     Args = A ++ EArgs,
     case do_start_child_i(M, F, Args) of
 	{ok, undefined} ->
-	    {reply, {ok, undefined}, State, State#state.hibernate_after};
+	    {reply, {ok, undefined}, State, hibernate_after_action(State)};
 	{ok, Pid} ->
 	    NState = dyn_store(Pid, Args, State),
-	    {reply, {ok, Pid}, NState, State#state.hibernate_after};
+	    {reply, {ok, Pid}, NState, hibernate_after_action(State)};
 	{ok, Pid, Extra} ->
 	    NState = dyn_store(Pid, Args, State),
-	    {reply, {ok, Pid, Extra}, NState, State#state.hibernate_after};
+	    {reply, {ok, Pid, Extra}, NState, hibernate_after_action(State)};
 	What ->
-	    {reply, What, State, State#state.hibernate_after}
+	    {reply, What, State, hibernate_after_action(State)}
     end;
 
 handle_call({start_child, ChildSpec}, _From, State) ->
     case check_childspec(ChildSpec, State#state.auto_shutdown) of
 	{ok, Child} ->
 	    {Resp, NState} = handle_start_child(Child, State),
-	    {reply, Resp, NState, State#state.hibernate_after};
+	    {reply, Resp, NState, hibernate_after_action(State)};
 	What ->
-	    {reply, {error, What}, State, State#state.hibernate_after}
+	    {reply, {error, What}, State, hibernate_after_action(State)}
     end;
 
 %% terminate_child for simple_one_for_one can only be done with pid
 handle_call({terminate_child, Id}, _From, State) when not is_pid(Id),
                                                       ?is_simple(State) ->
-    {reply, {error, simple_one_for_one}, State, State#state.hibernate_after};
+    {reply, {error, simple_one_for_one}, State, hibernate_after_action(State)};
 
 handle_call({terminate_child, Id}, _From, State) ->
     case find_child(Id, State) of
 	{ok, Child} ->
 	    do_terminate(Child, State#state.name),
-            {reply, ok, del_child(Child, State), State#state.hibernate_after};
+            {reply, ok, del_child(Child, State), hibernate_after_action(State)};
 	error ->
-	    {reply, {error, not_found}, State, State#state.hibernate_after}
+	    {reply, {error, not_found}, State, hibernate_after_action(State)}
     end;
 
 %% restart_child request is invalid for simple_one_for_one supervisors
 handle_call({restart_child, _Id}, _From, State) when ?is_simple(State) ->
-    {reply, {error, simple_one_for_one}, State, State#state.hibernate_after};
+    {reply, {error, simple_one_for_one}, State, hibernate_after_action(State)};
 
 handle_call({restart_child, Id}, _From, State) ->
     case find_child(Id, State) of
@@ -1050,44 +1051,44 @@ handle_call({restart_child, Id}, _From, State) ->
 	    case do_start_child(State#state.name, Child, debug_report) of
 		{ok, Pid} ->
 		    NState = set_pid(Pid, Id, State),
-		    {reply, {ok, Pid}, NState, State#state.hibernate_after};
+		    {reply, {ok, Pid}, NState, hibernate_after_action(State)};
 		{ok, Pid, Extra} ->
 		    NState = set_pid(Pid, Id, State),
-		    {reply, {ok, Pid, Extra}, NState, State#state.hibernate_after};
+		    {reply, {ok, Pid, Extra}, NState, hibernate_after_action(State)};
 		Error ->
-		    {reply, Error, State, State#state.hibernate_after}
+		    {reply, Error, State, hibernate_after_action(State)}
 	    end;
 	{ok, #child{pid=?restarting(_)}} ->
-	    {reply, {error, restarting}, State, State#state.hibernate_after};
+	    {reply, {error, restarting}, State, hibernate_after_action(State)};
 	{ok, _} ->
-	    {reply, {error, running}, State, State#state.hibernate_after};
+	    {reply, {error, running}, State, hibernate_after_action(State)};
 	_ ->
-	    {reply, {error, not_found}, State, State#state.hibernate_after}
+	    {reply, {error, not_found}, State, hibernate_after_action(State)}
     end;
 
 %% delete_child request is invalid for simple_one_for_one supervisors
 handle_call({delete_child, _Id}, _From, State) when ?is_simple(State) ->
-    {reply, {error, simple_one_for_one}, State, State#state.hibernate_after};
+    {reply, {error, simple_one_for_one}, State, hibernate_after_action(State)};
 
 handle_call({delete_child, Id}, _From, State) ->
     case find_child(Id, State) of
 	{ok, Child} when Child#child.pid =:= undefined ->
 	    NState = remove_child(Id, State),
-	    {reply, ok, NState, State#state.hibernate_after};
+	    {reply, ok, NState, hibernate_after_action(State)};
 	{ok, #child{pid=?restarting(_)}} ->
-	    {reply, {error, restarting}, State, State#state.hibernate_after};
+	    {reply, {error, restarting}, State, hibernate_after_action(State)};
 	{ok, _} ->
-	    {reply, {error, running}, State, State#state.hibernate_after};
+	    {reply, {error, running}, State, hibernate_after_action(State)};
 	_ ->
-	    {reply, {error, not_found}, State, State#state.hibernate_after}
+	    {reply, {error, not_found}, State, hibernate_after_action(State)}
     end;
 
 handle_call({get_childspec, Id}, _From, State) ->
     case find_child(Id, State) of
 	{ok, Child} ->
-            {reply, {ok, child_to_spec(Child)}, State, State#state.hibernate_after};
+            {reply, {ok, child_to_spec(Child)}, State, hibernate_after_action(State)};
 	error ->
-	    {reply, {error, not_found}, State, State#state.hibernate_after}
+	    {reply, {error, not_found}, State, hibernate_after_action(State)}
     end;
 
 handle_call(which_children, _From, State) when ?is_simple(State) ->
@@ -1095,7 +1096,7 @@ handle_call(which_children, _From, State) when ?is_simple(State) ->
     Reply = dyn_map(fun(?restarting(_)) -> {undefined, restarting, CT, Mods};
                        (Pid) -> {undefined, Pid, CT, Mods}
                     end, State),
-    {reply, Reply, State, State#state.hibernate_after};
+    {reply, Reply, State, hibernate_after_action(State)};
 
 handle_call(which_children, _From, State) ->
     Resp =
@@ -1108,12 +1109,12 @@ handle_call(which_children, _From, State) ->
                   {Id, Pid, ChildType, Mods}
           end,
           State#state.children),
-    {reply, Resp, State, State#state.hibernate_after};
+    {reply, Resp, State, hibernate_after_action(State)};
 
 %% which_child for simple_one_for_one can only be done with pid
 handle_call({which_child, Id}, _From, State) when not is_pid(Id),
                                                   ?is_simple(State) ->
-    {reply, {error, simple_one_for_one}, State, State#state.hibernate_after};
+    {reply, {error, simple_one_for_one}, State, hibernate_after_action(State)};
 
 handle_call({which_child, Pid}, _From, State) when ?is_simple(State) ->
     Result = case find_dynamic_child(Pid, State) of
@@ -1126,7 +1127,7 @@ handle_call({which_child, Pid}, _From, State) when ?is_simple(State) ->
 		 error ->
 		     {error, not_found}
 	     end,
-    {reply, Result, State, State#state.hibernate_after};
+    {reply, Result, State, hibernate_after_action(State)};
 
 handle_call({which_child, Id}, _From, State) ->
     Result = case find_child(Id, State) of
@@ -1139,7 +1140,7 @@ handle_call({which_child, Id}, _From, State) ->
 		 error ->
 		     {error, not_found}
 	     end,
-    {reply, Result, State, State#state.hibernate_after};
+    {reply, Result, State, hibernate_after_action(State)};
 
 handle_call(count_children, _From,  #state{dynamic_restarts = Restarts} = State)
   when ?is_simple(State) ->
@@ -1152,7 +1153,7 @@ handle_call(count_children, _From,  #state{dynamic_restarts = Restarts} = State)
 		worker -> [{specs, 1}, {active, Active},
 			   {supervisors, 0}, {workers, Sz}]
 	    end,
-    {reply, Reply, State, State#state.hibernate_after};
+    {reply, Reply, State, hibernate_after_action(State)};
 
 handle_call(count_children, _From, State) ->
     %% Specs and children are together on the children list...
@@ -1164,7 +1165,7 @@ handle_call(count_children, _From, State) ->
     %% Reformat counts to a property list.
     Reply = [{specs, Specs}, {active, Active},
 	     {supervisors, Supers}, {workers, Workers}],
-    {reply, Reply, State, State#state.hibernate_after}.
+    {reply, Reply, State, hibernate_after_action(State)}.
 
 count_child(#child{pid = Pid, child_type = worker},
 	    {Specs, Active, Supers, Workers}) ->
@@ -1184,19 +1185,19 @@ count_child(#child{pid = Pid, child_type = supervisor},
 %%% check it's inbox before trying again.
 -doc false.
 -spec handle_cast({try_again_restart, child_id() | {'restarting',pid()}}, state()) ->
-			 {'noreply', state()} | {stop, shutdown, state()}.
+			 {'noreply', state(), gen_server:action()} | {stop, shutdown, state()}.
 
 handle_cast({try_again_restart,TryAgainId}, State) ->
     case find_child_and_args(TryAgainId, State) of
 	{ok, Child = #child{pid=?restarting(_)}} ->
 	    case restart(Child,State) of
 		{ok, State1} ->
-		    {noreply, State1, State1#state.hibernate_after};
+		    {noreply, State1, hibernate_after_action(State)};
 		{shutdown, State1} ->
 		    {stop, shutdown, State1}
 	    end;
 	_ ->
-	    {noreply,State, State#state.hibernate_after}
+	    {noreply,State, hibernate_after_action(State)}
     end.
 
 %%
@@ -1204,16 +1205,15 @@ handle_cast({try_again_restart,TryAgainId}, State) ->
 %%
 -doc false.
 -spec handle_info(term(), state()) ->
-        {'noreply', state()} | {'stop', 'shutdown', state()}.
+        {'noreply', state(), gen_server:action()} | {'stop', 'shutdown', state()}.
 
-handle_info(timeout, State) ->
-    logger:notice("Hibernating supervisor ~p", [self()]),
+handle_info(HRef, #state{hibernate_after_ref = HRef} = State) ->
     {noreply, State, hibernate};
 
 handle_info({'EXIT', Pid, Reason}, State) ->
     case restart_child(Pid, Reason, State) of
 	{ok, State1} ->
-	    {noreply, State1, State1#state.hibernate_after};
+	    {noreply, State1, hibernate_after_action(State)};
 	{shutdown, State1} ->
 	    {stop, shutdown, State1}
     end;
@@ -1222,7 +1222,7 @@ handle_info(Msg, State) ->
     ?LOG_ERROR("Supervisor received unexpected message: ~tp~n",[Msg],
                #{domain=>[otp],
                  error_logger=>#{tag=>error}}),
-    {noreply, State, State#state.hibernate_after}.
+    {noreply, State, hibernate_after_action(State)}.
 
 %%
 %% Terminate this server.
@@ -1957,15 +1957,15 @@ check_flags(SupFlags) when is_map(SupFlags) ->
     case maps:merge(?default_flags, SupFlags) of
 	#{hibernate_after := _} = MergedFlags ->
 	    do_check_flags(MergedFlags);
-	#{strategy := Strategy} = MergedFlags ->
-	    do_check_flags(MergedFlags#{hibernate_after => default_hibernate_after(Strategy)})
+	#{strategy := Strategy, period := Period} = MergedFlags ->
+	    do_check_flags(MergedFlags#{hibernate_after => default_hibernate_after(Strategy, Period)})
     end;
 check_flags({Strategy, MaxIntensity, Period}) ->
     check_flags(#{strategy => Strategy,
 		  intensity => MaxIntensity,
 		  period => Period,
 		  auto_shutdown => never,
-		  hibernate_after => default_hibernate_after(Strategy)});
+		  hibernate_after => default_hibernate_after(Strategy, Period)});
 check_flags(What) ->
     throw({invalid_type, What}).
 
@@ -2020,10 +2020,16 @@ supname(self, Mod) -> {self(), Mod};
 supname(N, _)      -> N.
 
 
-default_hibernate_after(simple_one_for_one) ->
+-compile({inline, [hibernate_after_action/1]}).
+hibernate_after_action(#state{hibernate_after_ref = HRef, hibernate_after = HibernateAfter}) ->
+    {timeout, HibernateAfter, HRef}.
+
+default_hibernate_after(simple_one_for_one, _) ->
     infinity;
-default_hibernate_after(_) ->
-    0.
+default_hibernate_after(_, infinity) ->
+    5000;
+default_hibernate_after(_, Period) ->
+    1000 * Period.
 
 %%% ------------------------------------------------------
 %%% Check that the children start specification is valid.

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -430,8 +430,7 @@ see more details [above](`m:supervisor#sup_flags`).
 -define(default_flags, #{strategy        => one_for_one,
 			 intensity       => 1,
 			 period          => 5,
-			 auto_shutdown   => never,
-			 hibernate_after => undefined}).
+			 auto_shutdown   => never}).
 -define(default_child_spec, #{restart    => permanent,
 			      type       => worker}).
 %% Default 'shutdown' is 5000 for workers and infinity for supervisors.
@@ -464,7 +463,7 @@ see more details [above](`m:supervisor#sup_flags`).
                 nrestarts = 0,
 		dynamic_restarts = 0   :: non_neg_integer(),
 		auto_shutdown = never  :: auto_shutdown(),
-		hibernate_after        :: 'undefined' | timeout(),
+		hibernate_after        :: timeout(),
 	        module,
 	        args}).
 -type state() :: #state{}.
@@ -917,14 +916,7 @@ init_children(State, StartSpec) ->
         {ok, Children} ->
             case start_children(Children, SupName) of
                 {ok, NChildren} ->
-                    %% Static supervisor are not expected to
-                    %% have much work to do so hibernate them
-                    %% to improve memory handling.
-		    {HibernateAfter, TimeoutOrHibernate} = case State#state.hibernate_after of
-							       undefined -> {infinity, hibernate};
-							       Timeout -> {Timeout, Timeout}
-							   end,
-                    {ok, State#state{children = NChildren, hibernate_after = HibernateAfter}, TimeoutOrHibernate};
+                    {ok, State#state{children = NChildren}, State#state.hibernate_after};
                 {error, NChildren, Reason} ->
                     _ = terminate_children(NChildren, SupName),
                     {stop, {shutdown, Reason}}
@@ -936,14 +928,7 @@ init_children(State, StartSpec) ->
 init_dynamic(State, [StartSpec]) ->
     case check_startspec([StartSpec], State#state.auto_shutdown) of
         {ok, Children} ->
-            %% Simple one for one supervisors are expected to
-            %% have many children coming and going so do not
-            %% hibernate.
-	    HibernateAfter = case State#state.hibernate_after of
-				 undefined -> infinity;
-				 Timeout -> Timeout
-			     end,
-	    {ok, dyn_init(State#state{children = Children, hibernate_after = HibernateAfter}), HibernateAfter};
+	    {ok, dyn_init(State#state{children = Children}), State#state.hibernate_after};
         Error ->
             {stop, {start_spec, Error}}
     end;
@@ -1953,8 +1938,7 @@ init_state(SupName, Type, Mod, Args) ->
     set_flags(Type, #state{name = supname(SupName,Mod),
 			   module = Mod,
 			   args = Args,
-			   auto_shutdown = never,
-			   hibernate_after = undefined}).
+			   auto_shutdown = never}).
 
 set_flags(Flags, State) ->
     try check_flags(Flags) of
@@ -1970,13 +1954,18 @@ set_flags(Flags, State) ->
     end.
 
 check_flags(SupFlags) when is_map(SupFlags) ->
-    do_check_flags(maps:merge(?default_flags,SupFlags));
+    case maps:merge(?default_flags, SupFlags) of
+	#{hibernate_after := _} = MergedFlags ->
+	    do_check_flags(MergedFlags);
+	#{strategy := Strategy} = MergedFlags ->
+	    do_check_flags(MergedFlags#{hibernate_after => default_hibernate_after(Strategy)})
+    end;
 check_flags({Strategy, MaxIntensity, Period}) ->
     check_flags(#{strategy => Strategy,
 		  intensity => MaxIntensity,
 		  period => Period,
 		  auto_shutdown => never,
-		  hibernate_after => undefined});
+		  hibernate_after => default_hibernate_after(Strategy)});
 check_flags(What) ->
     throw({invalid_type, What}).
 
@@ -2019,10 +2008,9 @@ validAutoShutdownForStrategy(all_significant, simple_one_for_one) ->
 validAutoShutdownForStrategy(_AutoShutdown, _Strategy) ->
     true.
 
-validHibernateAfter(undefined) ->
+validHibernateAfter(infinity) ->
     true;
-validHibernateAfter(Timeout) when Timeout =:= infinity;
-				  is_integer(Timeout), Timeout >= 0 ->
+validHibernateAfter(Timeout) when is_integer(Timeout), Timeout >= 0 ->
     true;
 validHibernateAfter(What) ->
     throw({invalid_hibernate_after, What}).
@@ -2030,6 +2018,12 @@ validHibernateAfter(What) ->
 
 supname(self, Mod) -> {self(), Mod};
 supname(N, _)      -> N.
+
+
+default_hibernate_after(simple_one_for_one) ->
+    infinity;
+default_hibernate_after(_) ->
+    0.
 
 %%% ------------------------------------------------------
 %%% Check that the children start specification is valid.

--- a/lib/stdlib/test/supervisor_SUITE.erl
+++ b/lib/stdlib/test/supervisor_SUITE.erl
@@ -46,7 +46,7 @@
 	  sup_start_map_faulty_specs/1,
 	  sup_stop_infinity/1, sup_stop_timeout/1, sup_stop_timeout_dynamic/1,
 	  sup_stop_brutal_kill/1, sup_stop_brutal_kill_dynamic/1,
-          sup_stop_race/1, sup_stop_non_shutdown_exit_dynamic/1,
+          sup_stop_race/1, sup_stop_non_shutdown_exit_dynamic/1, auto_hibernate/1,
 	  child_adm/1, child_adm_simple/1, child_specs/1, child_specs_map/1,
 	  extra_return/1, sup_flags/1]).
 
@@ -102,7 +102,7 @@ suite() ->
 all() -> 
     [{group, sup_start}, {group, sup_start_map}, {group, sup_stop}, child_adm,
      child_adm_simple, extra_return, child_specs, child_specs_map, sup_flags,
-     multiple_restarts,
+     multiple_restarts, auto_hibernate,
      {group, restart_one_for_one},
      {group, restart_one_for_all},
      {group, restart_simple_one_for_one},
@@ -704,6 +704,36 @@ extra_return(Config) when is_list(Config) ->
             ok
     end.
 
+auto_hibernate(Config) when is_list(Config) ->
+    process_flag(trap_exit, true),
+    HibernateAfterTimeout = 100,
+    Child = {child1, {supervisor_1, start_child, []}, permanent, 1000,
+	     worker, []},
+    SupFlags = #{strategy => one_for_one,
+		 intensity => 2,
+		 period => 3600,
+                 hibernate_after => HibernateAfterTimeout},
+    {ok, SPid} = start_link({ok, {SupFlags, [Child]}}),
+
+    %% After init test
+    is_not_in_erlang_hibernate(SPid),
+    timer:sleep(HibernateAfterTimeout),
+    is_in_erlang_hibernate(SPid),
+
+    %% Trigger an action
+    [{child1, CPid, worker, []}] = supervisor:which_children(sup_test),
+    is_not_in_erlang_hibernate(SPid),
+    timer:sleep(HibernateAfterTimeout),
+    is_in_erlang_hibernate(SPid),
+
+    %% Kill a child
+    terminate(CPid, kill),
+    is_not_in_erlang_hibernate(SPid),
+    timer:sleep(HibernateAfterTimeout),
+    is_in_erlang_hibernate(SPid),
+
+    ok.
+
 %%-------------------------------------------------------------------------
 %% Test API functions start_child/2, terminate_child/2, delete_child/2
 %% restart_child/2, which_children/1, count_children/1. Only correct
@@ -713,7 +743,11 @@ child_adm(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     Child = {child1, {supervisor_1, start_child, []}, permanent, 1000,
 	     worker, []},
-    {ok, Pid} = start_link({ok, {{one_for_one, 2, 3600}, [Child]}}),
+    SupFlags = #{strategy => one_for_one,
+		 intensity => 1,
+		 period => 1000,
+                 hibernate_after => 0},
+    {ok, Pid} = start_link({ok, {SupFlags, [Child]}}),
 
     %% Test that supervisors of static nature are hibernated after start
     {current_function, {gen_server, loop_hibernate, 4}} =
@@ -3897,6 +3931,45 @@ ensure_supervisor_is_stopped() ->
             ok;
         Pid ->
             terminate(Pid, shutdown)
+    end.
+
+is_in_erlang_hibernate(Pid) ->
+    receive after 1 -> ok end,
+    is_in_erlang_hibernate_1(200, Pid).
+
+is_in_erlang_hibernate_1(0, Pid) ->
+    io:format("~p\n", [erlang:process_info(Pid, current_function)]),
+    ct:fail(not_in_erlang_hibernate_3);
+is_in_erlang_hibernate_1(N, Pid) ->
+    {current_function,MFA} = erlang:process_info(Pid, current_function),
+    case MFA of
+	{gen_server, loop_hibernate, 4} ->
+	    ok;
+	{erlang,hibernate,3} ->
+	    ok;
+	_ ->
+	    receive after 10 -> ok end,
+	    is_in_erlang_hibernate_1(N-1, Pid)
+    end.
+
+is_not_in_erlang_hibernate(Pid) ->
+    receive after 1 -> ok end,
+    is_not_in_erlang_hibernate_1(200, Pid).
+
+is_not_in_erlang_hibernate_1(0, Pid) ->
+    io:format("~p\n", [erlang:process_info(Pid, current_function)]),
+    ct:fail(not_in_erlang_hibernate_3);
+is_not_in_erlang_hibernate_1(N, Pid) ->
+    {current_function,MFA} = erlang:process_info(Pid, current_function),
+    case MFA of
+        {gen_server, loop_hibernate, 4} ->
+            receive after 10 -> ok end,
+            is_not_in_erlang_hibernate_1(N-1, Pid);
+        {erlang,hibernate,3} ->
+            receive after 10 -> ok end,
+            is_not_in_erlang_hibernate_1(N-1, Pid);
+        _ ->
+            ok
     end.
 
 %%-----------------------------------------------------------------


### PR DESCRIPTION
Spawning from https://github.com/erlang/otp/pull/9256, https://github.com/erlang/otp/pull/9287 and https://github.com/erlang/otp/pull/9621.

I've seen, first for SSL dynamic connection supervisors and then in general, that supervisors are losing a chance for memory optimisations. By default, "static" supervisors (not `simple_one_for_one`) would hibernate immediately after finishing initialisation (https://github.com/erlang/otp/blob/8dd0b477fbad981b7c19e301e901db7640087076/lib/stdlib/src/supervisor.erl#L916), as it is expected that they'll rather never have any activity again. This is however far too often not the case, as any children restart, as well as API operations like `which_children`, `which_child`, `start_child`, etc, would wake up the gen_server, which would then never hibernate again.

The idea then, is that a new flag can be given to a supervisor, telling it when to hibernate after any certain period of inactivity. Nobody better than the user knows when is this, considering a bunch of calls to `which_children` or `start_child` might be desired after init for example, so it is allowed the user provides this. However by default it is infinity for dynamic supervisors, as it is expected they'll have a high activity of children going up and down; and equal to the period for static supervisors, as it is a good compromise to keep a supervisor responsive under bursts of children restarts.